### PR TITLE
Fix serverUrl not being set if default port is used

### DIFF
--- a/packages/TeamCityAgent/tools/chocolateyInstall.ps1
+++ b/packages/TeamCityAgent/tools/chocolateyInstall.ps1
@@ -51,8 +51,8 @@ $buildAgentConfig = get-content $agentDir\conf\buildAgent.properties
 if ($ownPort -eq "9090") {
 # Simply replace config elements sinnce we aren't adding any new entries
 $buildAgentConfig | Foreach-Object {
-    $_ -replace 'serverUrl=(\S+)', "serverUrl=$serverUrl" `
-	   -replace 'name=(\S+)', "name=$agentName"
+    $_ -replace 'serverUrl=(?:\S+)', "serverUrl=$serverUrl" `
+	   -replace 'name=(?:\S+)', "name=$agentName"
     } | Set-Content $agentDir\conf\buildAgent.properties
 } else {
 # Rewrite the entire config since we are adding a new element and this can be tricky to get right

--- a/packages/TeamCityAgent/tools/chocolateyInstall.ps1
+++ b/packages/TeamCityAgent/tools/chocolateyInstall.ps1
@@ -51,8 +51,8 @@ $buildAgentConfig = get-content $agentDir\conf\buildAgent.properties
 if ($ownPort -eq "9090") {
 # Simply replace config elements sinnce we aren't adding any new entries
 $buildAgentConfig | Foreach-Object {
-    $_ -replace 'serverUrl=http://localhost:8111/', "serverUrl=$serverUrl" `
-	   -replace 'name=', "name=$agentName"
+    $_ -replace 'serverUrl=(\S+)', "serverUrl=$serverUrl" `
+	   -replace 'name=(\S+)', "name=$agentName"
     } | Set-Content $agentDir\conf\buildAgent.properties
 } else {
 # Rewrite the entire config since we are adding a new element and this can be tricky to get right


### PR DESCRIPTION
Trying to improve the flexibility of the matcher to handle empty or values containing spaces.